### PR TITLE
add_spp for RRTMG

### DIFF
--- a/physics/GFS_rrtmg_pre.F90
+++ b/physics/GFS_rrtmg_pre.F90
@@ -35,7 +35,7 @@
         gasvmr_o2, gasvmr_co, gasvmr_cfc11, gasvmr_cfc12, gasvmr_cfc22,        &
         gasvmr_ccl4,  gasvmr_cfc113, aerodp, clouds6, clouds7, clouds8,        &
         clouds9, cldsa, cldfra, faersw1, faersw2, faersw3, faerlw1, faerlw2,   &
-        faerlw3, alpha, errmsg, errflg)
+        faerlw3, alpha, spp_wts_rad, do_spp, errmsg, errflg)
 
       use machine,                   only: kind_phys
 
@@ -98,6 +98,9 @@
       logical,              intent(in) :: lsswr, lslwr, ltaerosol, lgfdlmprad, &
                                           uni_cld, effr_in, do_mynnedmf,       &
                                           lmfshal, lmfdeep2
+
+      logical,    optional, intent(in) :: do_spp
+      real(kind_phys),              intent(in) :: spp_wts_rad(:,:)
 
       real(kind=kind_phys), intent(in) :: fhswr, fhlwr, solhr, sup, julian
       real(kind=kind_phys), intent(in) :: eps, epsm1, fvirt, rog, rocp, con_rd
@@ -1052,6 +1055,27 @@
             cldfra(i,k)   = clouds(i,k,1)
          enddo
        enddo
+
+! --- add spp
+      if ( do_spp .ne. 0 ) then
+
+      do k=1,lm
+        if (k < levs) then
+          do i=1,im
+            effrl_inout(i,k) = effrl_inout(i,k) - spp_wts_rad(i,k) * effrl_inout(i,k)
+            effri_inout(i,k) = effri_inout(i,k) - spp_wts_rad(i,k) * effri_inout(i,k)
+            effrs_inout(i,k) = effrs_inout(i,k) - spp_wts_rad(i,k) * effrs_inout(i,k)
+          enddo
+        else
+          do i=1,im
+            effrl_inout(i,k) = effrl_inout(i,k) - spp_wts_rad(i,levs) * effrl_inout(i,k)
+            effri_inout(i,k) = effri_inout(i,k) - spp_wts_rad(i,levs) * effri_inout(i,k)
+            effrs_inout(i,k) = effrs_inout(i,k) - spp_wts_rad(i,levs) * effrs_inout(i,k)
+          enddo
+        endif
+      enddo
+
+      endif
 
 ! mg, sfc-perts
 !  ---  scale random patterns for surface perturbations with

--- a/physics/GFS_rrtmg_pre.meta
+++ b/physics/GFS_rrtmg_pre.meta
@@ -1151,6 +1151,23 @@
   kind = kind_phys
   intent = out
   optional = F
+[spp_wts_rad]
+  standard_name = weights_for_stochastic_spp_rad_perturbation
+  long_name = weights for stochastic spp rad perturbation
+  units = none
+  dimensions = (horizontal_loop_extent,vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[do_spp]
+  standard_name = flag_for_stochastic_spp_option
+  long_name = flag for stochastic spp option
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
 [errmsg]
   standard_name = ccpp_error_message
   long_name = error message for error handling in CCPP

--- a/physics/mp_thompson.F90
+++ b/physics/mp_thompson.F90
@@ -480,10 +480,9 @@ module mp_thompson
          ! For now (22Mar2018), standard deviation should be only 0.25 and cut-off at 1.5
          ! in order to constrain the various perturbations from being too extreme.
          !+---+-----------------------------------------------------------------+
-         integer, parameter :: spp_mp = 7 ! default as 7 to perturb all three fields 
+         integer, parameter :: spp_mp = 7 ! hard coded as 7 to perturb all three fields 
          ! spp_wts_mp only allocated if do_spp == .true.
          real(kind_phys),              intent(in) :: spp_wts_mp(:,:)
-         real(kind_phys) :: pattern_spp_mp(1:ncol,1:nlev)
          ! Dimensions used in mp_gt_driver
          integer         :: ids,ide, jds,jde, kds,kde, &
                             ims,ime, jms,jme, kms,kme, &
@@ -600,20 +599,6 @@ module mp_thompson
          kme = nlev
          kte = nlev
 
-         do k=1,nlev
-            do i=1,ncol
-                pattern_spp_mp(i,k)=0.0
-            enddo
-         enddo
-
-         if ( do_spp ) then
-            do k=1,nlev
-                do i=1,ncol
-                    pattern_spp_mp(i,k)=spp_wts_mp(i,k)
-                enddo
-            enddo
-         endif
-
          !> - Call mp_gt_driver() with or without aerosols
          if (is_aerosol_aware) then
             call mp_gt_driver(qv=qv_mp, qc=qc_mp, qr=qr_mp, qi=qi_mp, qs=qs_mp, qg=qg_mp,    &
@@ -631,7 +616,7 @@ module mp_thompson
                               rand_perturb_on=spp_mp, kme_stoch=kme_stoch,                   &
                               ! DH* 2020-06-05 not passing this optional argument, see
                               !       comment in module_mp_thompson.F90 / mp_gt_driver
-                              rand_pert=pattern_spp_mp,                                      &
+                              rand_pert=spp_wts_mp,                                      &
                               ids=ids, ide=ide, jds=jds, jde=jde, kds=kds, kde=kde,          &
                               ims=ims, ime=ime, jms=jms, jme=jme, kms=kms, kme=kme,          &
                               its=its, ite=ite, jts=jts, jte=jte, kts=kts, kte=kte,          &
@@ -652,7 +637,7 @@ module mp_thompson
                               rand_perturb_on=spp_mp, kme_stoch=kme_stoch,                   &
                               ! DH* 2020-06-05 not passing this optional argument, see
                               !       comment in module_mp_thompson.F90 / mp_gt_driver
-                              rand_pert=pattern_spp_mp,                                      &
+                              rand_pert=spp_wts_mp,                                      &
                               ids=ids, ide=ide, jds=jds, jde=jde, kds=kds, kde=kde,          &
                               ims=ims, ime=ime, jms=jms, jme=jme, kms=kms, kme=kme,          &
                               its=its, ite=ite, jts=jts, jte=jte, kts=kts, kte=kte,          &


### PR DESCRIPTION
@llpcarson @JeffBeck-NOAA

Added spp to RRTMG radiation scheme in CCPP. Compiled successfully and currently being tested using UFS SRW.

Issue needs a special review: As in WRF, we are subtracting the variable pattern_spp with a dimension of (im, levs) to effective radii of cloud/ice/snow variables with a dimension of (im, lm). As you know, in CCPP, “levs” is “vertical_dimension" and “lm” is “number_of_vertical_layers_for_radiation_calculation”, so we end it up with incompatible dimensions to do arithmetic operation… The code is updated by assuming the overlapping layers between lm and levs are the same and putting a IF statement to separate (lm < levs) or (lm >=levs) scenarios. If (lm >=levs), for layers above "levs", the perturbation patterns are all treated as equal to pattern_spp (i, levs). 

modified:   physics/GFS_rrtmg_pre.F90	
modified:   physics/GFS_rrtmg_pre.meta